### PR TITLE
remove deprecated `escape` in export.js

### DIFF
--- a/web/js/export.js
+++ b/web/js/export.js
@@ -98,7 +98,7 @@ function mediatum_load(id, limit, sort, query, format, language, type, detailof)
                 url += "&files=all";
             }
 
-            url += query ? "&q="+escape(query) : "";
+            url += query ? "&q="+encodeURIComponent(query) : "";
             url += "&sortfield="+sort
             url += limit ? "&limit="+limit : "";
             url += format ? "&format="+format : "";


### PR DESCRIPTION
Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features