### PR TITLE
Security: Enable LDAP TLS certificate verification by default

### DIFF
--- a/core/ldapauth.py
+++ b/core/ldapauth.py
@@ -19,7 +19,21 @@ from utils.compat import iteritems
 
 logg = logging.getLogger(__name__)
 
-ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+# TLS certificate verification settings
+# OPT_X_TLS_DEMAND requires TLS, OPT_X_TLS_HARD requires valid certificate
+# To disable certificate verification (NOT RECOMMENDED), set ldap.tls_require_cert=never in config
+_tls_require_cert_options = {
+    "never": ldap.OPT_X_TLS_NEVER,
+    "allow": ldap.OPT_X_TLS_ALLOW,
+    "try": ldap.OPT_X_TLS_TRY,
+    "demand": ldap.OPT_X_TLS_DEMAND,
+    "hard": ldap.OPT_X_TLS_HARD,
+}
+_tls_require_cert = config.get("ldap.tls_require_cert", "demand").lower()
+if _tls_require_cert not in _tls_require_cert_options:
+    logg.warning("Invalid ldap.tls_require_cert value '%s', using 'demand'", _tls_require_cert)
+    _tls_require_cert = "demand"
+ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, _tls_require_cert_options[_tls_require_cert])
 ldap.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)
 ldap.set_option(ldap.OPT_REFERRALS, 0)
 


### PR DESCRIPTION
## Summary
- Fix critical security vulnerability: LDAP TLS certificate verification was disabled
- Changed default from `OPT_X_TLS_NEVER` to `OPT_X_TLS_DEMAND` 
- Added configurable option `ldap.tls_require_cert` for environments that need self-signed certs

## Security Impact
Previously, the LDAP connection was vulnerable to man-in-the-middle attacks because certificate verification was completely disabled. This fix ensures certificates are validated by default.

## Test plan
- [ ] Test LDAP authentication with valid certificates (should work)
- [ ] Test LDAP authentication with invalid/expired certificates (should fail)
- [ ] Test with `ldap.tls_require_cert=never` config for backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)