### PR TITLE
Security: Add secure cookie flags for session protection

### DIFF
--- a/core/init.py
+++ b/core/init.py
@@ -82,6 +82,12 @@ def _make_app():
         )
     app.config['PERMANENT_SESSION_LIFETIME'] = int(config.get('admin.session_expiration_time', 7200))
     app.config["SESSION_COOKIE_NAME"] = 'mediatum_session'
+    # Security: prevent JavaScript access to session cookie (mitigates XSS)
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+    # Security: only send cookie over HTTPS (configurable for dev environments)
+    app.config["SESSION_COOKIE_SECURE"] = config.getboolean('admin.session_cookie_secure', True)
+    # Security: prevent CSRF by restricting cookie sending to same-site requests
+    app.config["SESSION_COOKIE_SAMESITE"] = 'Lax'
 
     @app.before_request
     def set_lang():


### PR DESCRIPTION
## Summary
- Add `SESSION_COOKIE_HTTPONLY=True` to prevent JavaScript access to session cookie
- Add `SESSION_COOKIE_SECURE` (defaults to True, configurable for dev)
- Add `SESSION_COOKIE_SAMESITE='Lax'` to prevent CSRF attacks

## Security Impact
Without these flags, session cookies could be:
- Stolen via XSS attacks (no HttpOnly)
- Intercepted over HTTP connections (no Secure)
- Sent in cross-site requests (no SameSite)

## Test plan
- [ ] Verify session cookies have HttpOnly flag in browser dev tools
- [ ] Verify session cookies have Secure flag when using HTTPS
- [ ] Verify session cookies have SameSite=Lax attribute
- [ ] Test `admin.session_cookie_secure=false` for dev environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)