### PR TITLE
Security: Use constant-time comparison for passwords and signatures

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -7,6 +7,7 @@ from __future__ import division
 from __future__ import print_function
 
 from base64 import b64encode
+import hmac
 import logging
 import os
 import hashlib
@@ -31,7 +32,9 @@ def generate_salt():
 
 
 def check_user_password(user, password):
-    return user.password_hash == b64encode(scrypt.hash(password.encode("utf8"), str(user.salt)))
+    # Use constant-time comparison to prevent timing attacks
+    computed_hash = b64encode(scrypt.hash(password.encode("utf8"), str(user.salt)))
+    return hmac.compare_digest(user.password_hash, computed_hash)
 
 
 def create_password_hash(password, salt=None):
@@ -128,7 +131,8 @@ class InternalAuthenticator(Authenticator):
                     return user
             else:
                 # check legacy md5 hash directly
-                if user.password_hash == create_md5_hash(password):
+                # Use constant-time comparison to prevent timing attacks
+                if hmac.compare_digest(user.password_hash, create_md5_hash(password)):
                     rehashed = rehash_legacy_password(password)
                     # not rehashing md5 is NOT ok, let's warn...
                     if not rehashed:

--- a/core/oauth.py
+++ b/core/oauth.py
@@ -6,6 +6,7 @@
 from __future__ import division
 from __future__ import print_function
 
+import hmac
 import logging
 import hashlib
 
@@ -66,7 +67,8 @@ def verify_request_signature(req_path, params):
         workingString += '{}={}'.format(oneKey,
                                         oneValue)
     testSignature = hashlib.md5(workingString).hexdigest()
-    return (testSignature == signature)
+    # Use constant-time comparison to prevent timing attacks
+    return hmac.compare_digest(testSignature, signature)
 
 
 def get_oauth_key_for_user(user):


### PR DESCRIPTION
## Summary
- Replace `==` with `hmac.compare_digest()` for password hash comparisons
- Replace `==` with `hmac.compare_digest()` for OAuth signature verification
- Prevents timing attacks that could leak credential information

## Files Changed
- `core/auth.py`: Fixed scrypt and MD5 password comparisons
- `core/oauth.py`: Fixed OAuth signature comparison

## Security Impact
Direct string comparison (`==`) reveals timing information that attackers can exploit to determine correct values character-by-character. `hmac.compare_digest()` performs comparison in constant time regardless of input.

## Test plan
- [ ] Verify password authentication still works
- [ ] Verify OAuth signature verification still works
- [ ] (Optional) Verify timing consistency with profiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)