### PR TITLE
Security: Validate thumbframe parameter to prevent command injection

### DIFF
--- a/contenttypes/video.py
+++ b/contenttypes/video.py
@@ -125,7 +125,14 @@ class Video(Content):
             ffmpeg_call = ["ffmpeg", "-y"]
 
             if thumbframe:
-                ffmpeg_call += ['-ss', str(thumbframe)]  # change frame used as thumbnail
+                # Validate thumbframe is a number to prevent command injection
+                try:
+                    thumbframe_num = float(thumbframe)
+                    if thumbframe_num < 0:
+                        raise ValueError("thumbframe must be non-negative")
+                    ffmpeg_call += ['-ss', str(thumbframe_num)]  # change frame used as thumbnail
+                except (ValueError, TypeError) as e:
+                    logg.warning("Invalid thumbframe value '%s': %s. Using default.", thumbframe, e)
 
             ffmpeg_call += ['-i', video_file.abspath]  # input settings
 


### PR DESCRIPTION
## Summary
- Add numeric validation for the `thumbframe` system attribute
- Validate value is a non-negative number before passing to ffmpeg
- Log warning and use default frame if validation fails

## Security Impact
The `thumbframe` attribute could be set via admin interface and was
passed directly to ffmpeg. While the argument list approach mitigates
most shell injection risks, validating input is defense in depth.

## Files Changed
- `contenttypes/video.py`: Added validation in `event_files_changed()`

## Test plan
- [ ] Test video upload with default thumbnails (no thumbframe set)
- [ ] Test video with valid thumbframe (e.g., "5.0")
- [ ] Test video with invalid thumbframe (e.g., "abc") - should log warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)