### PR TITLE
Security: Fix XSS vulnerability in search template

### DIFF
--- a/web/themes/mediatum/templates/search_noresult.j2.jade
+++ b/web/themes/mediatum/templates/search_noresult.j2.jade
@@ -6,7 +6,7 @@ if language == 'de'
   h2 Keine Suchergebnisse
   p
     | Für Ihre Suchanfrage "
-    b #{query}
+    b= query
     | " wurden keine Ergebnisse gefunden.
   h2 Gesucht wurde in:
   ul(type='square')
@@ -48,7 +48,7 @@ else
   h2 No search results
   p
     | For your query "
-    b #{query}
+    b= query
     | " no results were found.
   h2 The following has been searched:
   ul(type='square')


### PR DESCRIPTION
## Summary
- Fix XSS vulnerability in search results "no results" page
- Change query output from unescaped `#{query}` to escaped `= query`

## Security Impact
The `#{query}` Jade syntax outputs content without HTML escaping. Attackers could inject malicious JavaScript via search queries like:
```
<script>alert('xss')</script>
```

## Files Changed
- `web/themes/mediatum/templates/search_noresult.j2.jade`

## Test plan
- [ ] Search for normal text - displays correctly
- [ ] Search for `<script>alert('test')</script>` - should show escaped HTML, not execute script
- [ ] Search for `<img src=x onerror=alert('xss')>` - should show escaped HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)